### PR TITLE
refactor(security): 접근 허용 경로 컨버트 로직 추상화

### DIFF
--- a/src/main/java/com/handwoong/rainbowletter/config/security/AccessAllowUri.java
+++ b/src/main/java/com/handwoong/rainbowletter/config/security/AccessAllowUri.java
@@ -1,24 +1,13 @@
 package com.handwoong.rainbowletter.config.security;
 
-import java.util.Arrays;
-
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum AccessAllowUri {
+public enum AccessAllowUri implements AllowUri {
     ROOT("/"),
     INDEX("/index.html");
 
     private final String uri;
-
-    public static AntPathRequestMatcher[] convertPathMatcher() {
-        return Arrays.stream(AccessAllowUri.values())
-                .map(AccessAllowUri::getUri)
-                .map(AntPathRequestMatcher::antMatcher)
-                .toArray(AntPathRequestMatcher[]::new);
-    }
 }

--- a/src/main/java/com/handwoong/rainbowletter/config/security/AllowUri.java
+++ b/src/main/java/com/handwoong/rainbowletter/config/security/AllowUri.java
@@ -1,0 +1,5 @@
+package com.handwoong.rainbowletter.config.security;
+
+public interface AllowUri {
+    String getUri();
+}

--- a/src/main/java/com/handwoong/rainbowletter/config/security/AnonymousAllowUri.java
+++ b/src/main/java/com/handwoong/rainbowletter/config/security/AnonymousAllowUri.java
@@ -1,24 +1,13 @@
 package com.handwoong.rainbowletter.config.security;
 
-import java.util.Arrays;
-
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum AnonymousAllowUri {
+public enum AnonymousAllowUri implements AllowUri {
     USER_REGISTER("/api/members"),
     USER_LOGIN("/api/members/login");
 
     private final String uri;
-
-    public static AntPathRequestMatcher[] convertPathMatcher() {
-        return Arrays.stream(AnonymousAllowUri.values())
-                .map(AnonymousAllowUri::getUri)
-                .map(AntPathRequestMatcher::antMatcher)
-                .toArray(AntPathRequestMatcher[]::new);
-    }
 }

--- a/src/main/java/com/handwoong/rainbowletter/config/security/CorsConfig.java
+++ b/src/main/java/com/handwoong/rainbowletter/config/security/CorsConfig.java
@@ -13,7 +13,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @Configuration
 public class CorsConfig {
     @Bean
-    public CorsConfigurationSource corsConfigurationSource(@Value("${client.url}") final String url) {
+    public CorsConfigurationSource corsConfigurationSource(@Value("#{${client.url}}") final String url) {
         final CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowCredentials(true);
         configuration.setAllowedOrigins(List.of(url));

--- a/src/main/java/com/handwoong/rainbowletter/config/security/SecurityConfig.java
+++ b/src/main/java/com/handwoong/rainbowletter/config/security/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.handwoong.rainbowletter.config.security;
 
+import java.util.Arrays;
+
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,6 +13,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.CorsConfigurationSource;
 
 import lombok.RequiredArgsConstructor;
@@ -44,8 +47,8 @@ public class SecurityConfig {
         http.authorizeHttpRequests(auth ->
                 auth
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
-                        .requestMatchers(AccessAllowUri.convertPathMatcher()).permitAll()
-                        .requestMatchers(AnonymousAllowUri.convertPathMatcher()).anonymous()
+                        .requestMatchers(convertUriToPathMatcher(AccessAllowUri.values())).permitAll()
+                        .requestMatchers(convertUriToPathMatcher(AnonymousAllowUri.values())).anonymous()
                         .anyRequest().authenticated()
         );
     }
@@ -64,5 +67,12 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    private AntPathRequestMatcher[] convertUriToPathMatcher(final AllowUri[] allowUris) {
+        return Arrays.stream(allowUris)
+                .map(AllowUri::getUri)
+                .map(AntPathRequestMatcher::antMatcher)
+                .toArray(AntPathRequestMatcher[]::new);
     }
 }


### PR DESCRIPTION
### 구현 목록

- [x] 전체 접근 허용 경로 및 미인증 사용자 접근 허용 경로 `String` -> `AntPathRequestMatcher` 컨버트 로직 중복 제거

Close #15 