### PR TITLE
feat(letter): 임시 ChatGPT 편지 답장 생성 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.3'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'

--- a/src/main/java/com/handwoong/rainbowletter/config/PropertiesConfig.java
+++ b/src/main/java/com/handwoong/rainbowletter/config/PropertiesConfig.java
@@ -15,4 +15,10 @@ public class PropertiesConfig {
 
     @Value("#{${client.url}}")
     private List<String> clientUrls;
+
+    @Value("${chatgpt.token}")
+    private String chatgptToken;
+
+    @Value("${airtable.token}")
+    private String airtableToken;
 }

--- a/src/main/java/com/handwoong/rainbowletter/config/api/RestTemplateConfig.java
+++ b/src/main/java/com/handwoong/rainbowletter/config/api/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.handwoong.rainbowletter.config.api;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate(new HttpComponentsClientHttpRequestFactory());
+    }
+}

--- a/src/main/java/com/handwoong/rainbowletter/config/security/AccessAllowUri.java
+++ b/src/main/java/com/handwoong/rainbowletter/config/security/AccessAllowUri.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum AccessAllowUri implements AllowUri {
     ROOT("/"),
     INDEX("/index.html"),
-    EMAIL_VERIFY("/api/members/verify/**");
+    EMAIL_VERIFY("/api/members/verify/**"),
+    REPLY_LETTER("/api/letters");
 
     private final String uri;
 }

--- a/src/main/java/com/handwoong/rainbowletter/controller/letter/LetterController.java
+++ b/src/main/java/com/handwoong/rainbowletter/controller/letter/LetterController.java
@@ -1,0 +1,26 @@
+package com.handwoong.rainbowletter.controller.letter;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.handwoong.rainbowletter.dto.letter.ReplyRequestDto;
+import com.handwoong.rainbowletter.service.letter.LetterService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/letters")
+public class LetterController {
+    private final LetterService letterService;
+
+    @PostMapping
+    public ResponseEntity<Void> reply(@RequestBody final ReplyRequestDto replyRequest) {
+        letterService.reply(replyRequest);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/handwoong/rainbowletter/dto/letter/AirtableUpdateDto.java
+++ b/src/main/java/com/handwoong/rainbowletter/dto/letter/AirtableUpdateDto.java
@@ -1,0 +1,9 @@
+package com.handwoong.rainbowletter.dto.letter;
+
+public record AirtableUpdateDto(
+        String GPT,
+        int prompt_tokens,
+        int completion_tokens,
+        int total_tokens
+) {
+}

--- a/src/main/java/com/handwoong/rainbowletter/dto/letter/AirtableUpdateRequestDto.java
+++ b/src/main/java/com/handwoong/rainbowletter/dto/letter/AirtableUpdateRequestDto.java
@@ -1,0 +1,6 @@
+package com.handwoong.rainbowletter.dto.letter;
+
+public record AirtableUpdateRequestDto(
+        AirtableUpdateDto fields
+) {
+}

--- a/src/main/java/com/handwoong/rainbowletter/dto/letter/ChatGptMessage.java
+++ b/src/main/java/com/handwoong/rainbowletter/dto/letter/ChatGptMessage.java
@@ -1,0 +1,7 @@
+package com.handwoong.rainbowletter.dto.letter;
+
+public record ChatGptMessage(
+        String role,
+        String content
+) {
+}

--- a/src/main/java/com/handwoong/rainbowletter/dto/letter/ChatGptRequestDto.java
+++ b/src/main/java/com/handwoong/rainbowletter/dto/letter/ChatGptRequestDto.java
@@ -1,0 +1,14 @@
+package com.handwoong.rainbowletter.dto.letter;
+
+import java.util.List;
+
+public record ChatGptRequestDto(
+        String model,
+        List<ChatGptMessage> messages,
+        Long max_tokens,
+        Double temperature,
+        Double top_p,
+        Double frequency_penalty,
+        Double presence_penalty
+) {
+}

--- a/src/main/java/com/handwoong/rainbowletter/dto/letter/ChatGptResponseChoice.java
+++ b/src/main/java/com/handwoong/rainbowletter/dto/letter/ChatGptResponseChoice.java
@@ -1,0 +1,8 @@
+package com.handwoong.rainbowletter.dto.letter;
+
+public record ChatGptResponseChoice(
+        ChatGptMessage message,
+        int index,
+        String finish_reason
+) {
+}

--- a/src/main/java/com/handwoong/rainbowletter/dto/letter/ChatGptResponseDto.java
+++ b/src/main/java/com/handwoong/rainbowletter/dto/letter/ChatGptResponseDto.java
@@ -1,0 +1,13 @@
+package com.handwoong.rainbowletter.dto.letter;
+
+import java.util.List;
+
+public record ChatGptResponseDto(
+        String id,
+        String object,
+        int created,
+        String model,
+        List<ChatGptResponseChoice> choices,
+        ChatGptResponseUsage usage
+) {
+}

--- a/src/main/java/com/handwoong/rainbowletter/dto/letter/ChatGptResponseUsage.java
+++ b/src/main/java/com/handwoong/rainbowletter/dto/letter/ChatGptResponseUsage.java
@@ -1,0 +1,8 @@
+package com.handwoong.rainbowletter.dto.letter;
+
+public record ChatGptResponseUsage(
+        int prompt_tokens,
+        int completion_tokens,
+        int total_tokens
+) {
+}

--- a/src/main/java/com/handwoong/rainbowletter/dto/letter/ReplyRequestDto.java
+++ b/src/main/java/com/handwoong/rainbowletter/dto/letter/ReplyRequestDto.java
@@ -1,0 +1,9 @@
+package com.handwoong.rainbowletter.dto.letter;
+
+public record ReplyRequestDto(
+        String baseId,
+        String recordId,
+        String tableName,
+        ChatGptRequestDto body
+) {
+}

--- a/src/main/java/com/handwoong/rainbowletter/service/letter/LetterService.java
+++ b/src/main/java/com/handwoong/rainbowletter/service/letter/LetterService.java
@@ -1,0 +1,7 @@
+package com.handwoong.rainbowletter.service.letter;
+
+import com.handwoong.rainbowletter.dto.letter.ReplyRequestDto;
+
+public interface LetterService {
+    void reply(final ReplyRequestDto replyRequest);
+}

--- a/src/main/java/com/handwoong/rainbowletter/service/letter/LetterServiceImpl.java
+++ b/src/main/java/com/handwoong/rainbowletter/service/letter/LetterServiceImpl.java
@@ -1,0 +1,69 @@
+package com.handwoong.rainbowletter.service.letter;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import com.handwoong.rainbowletter.config.PropertiesConfig;
+import com.handwoong.rainbowletter.dto.letter.AirtableUpdateDto;
+import com.handwoong.rainbowletter.dto.letter.AirtableUpdateRequestDto;
+import com.handwoong.rainbowletter.dto.letter.ChatGptRequestDto;
+import com.handwoong.rainbowletter.dto.letter.ChatGptResponseDto;
+import com.handwoong.rainbowletter.dto.letter.ReplyRequestDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LetterServiceImpl implements LetterService {
+    private static final String OPEN_API_URL = "https://api.openai.com/v1/chat/completions";
+
+    private final RestTemplate restTemplate;
+    private final PropertiesConfig propertiesConfig;
+
+    @Override
+    @Async
+    public void reply(final ReplyRequestDto replyRequest) {
+        final ChatGptResponseDto chatGptResponse = requestChatGpt(replyRequest);
+        updateAirtable(replyRequest, chatGptResponse);
+    }
+
+    private ChatGptResponseDto requestChatGpt(final ReplyRequestDto replyRequest) {
+        final HttpHeaders chatGptHeaders = new HttpHeaders();
+        chatGptHeaders.setContentType(MediaType.APPLICATION_JSON);
+        chatGptHeaders.add("Authorization", "Bearer " + propertiesConfig.getChatgptToken());
+        final HttpEntity<ChatGptRequestDto> chatGptRequest = new HttpEntity<>(replyRequest.body(), chatGptHeaders);
+        return restTemplate.exchange(OPEN_API_URL, HttpMethod.POST, chatGptRequest, ChatGptResponseDto.class).getBody();
+    }
+
+    private void updateAirtable(final ReplyRequestDto replyRequest, final ChatGptResponseDto chatGptResponse) {
+        assert chatGptResponse != null;
+        final String output = chatGptResponse.choices().get(0).message().content();
+        final int promptTokens = chatGptResponse.usage().prompt_tokens();
+        final int completionTokens = chatGptResponse.usage().completion_tokens();
+        final int totalTokens = chatGptResponse.usage().total_tokens();
+
+        final HttpHeaders airtableHeaders = new HttpHeaders();
+        airtableHeaders.setContentType(MediaType.APPLICATION_JSON);
+        airtableHeaders.add("Authorization", "Bearer " + propertiesConfig.getAirtableToken());
+
+        final String airtableUrl = "https://api.airtable.com/v0/"
+                + replyRequest.baseId()
+                + "/"
+                + replyRequest.tableName()
+                + "/"
+                + replyRequest.recordId();
+
+        final AirtableUpdateDto airtableUpdateDto =
+                new AirtableUpdateDto(output, promptTokens, completionTokens, totalTokens);
+        final HttpEntity<AirtableUpdateRequestDto> airtableRequest =
+                new HttpEntity<>(new AirtableUpdateRequestDto(airtableUpdateDto), airtableHeaders);
+        restTemplate.exchange(airtableUrl, HttpMethod.PATCH, airtableRequest, Object.class);
+    }
+}


### PR DESCRIPTION
## 설명

서비스 이전 전 에어테이블 자동화 시간 초과로 인해 서버에서 비동기로 API를 제공하여 시간 초과를 방지한다.

## 작업

- [x] ChatGPT를 이용해 편지 답장 생성
- [x] 생성된 답장을 에어테이블에 반영

Close #41 