### PR TITLE
fix(docs): spring rest docs 이전 빌드 API 문서가 보이는 현상 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ tasks.named('test') {
 }
 
 asciidoctor.doFirst {
-    delete file('src/main/resources/static/docs')
+    delete file('src/main/resources/static')
 }
 
 asciidoctor {


### PR DESCRIPTION
## 설명

빌드 시 업데이트 된 API 문서가 아닌 이전 API 문서가 보여진다.

## 작업

- [x] gradle 스크립트 수정

Close #43 