### PR TITLE
feat(member): 휴대폰 번호 등록 및 변경 기능 구현

### DIFF
--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -59,3 +59,11 @@ operation::member-controller-test/invalid_change_password[snippets='http-request
 === Case 비밀번호 찾기 비밀번호 변경
 
 operation::member-controller-test/reset_password[snippets='http-request,http-response']
+
+=== 휴대폰 번호 변경
+
+operation::member-controller-test/change_phone_number[snippets='http-request,http-response']
+
+=== [ERROR] 유효하지 않은 휴대폰 번호 형식
+
+operation::member-controller-test/invalid_phone_number[snippets='http-request,http-response']

--- a/src/main/java/com/handwoong/rainbowletter/controller/member/MemberController.java
+++ b/src/main/java/com/handwoong/rainbowletter/controller/member/MemberController.java
@@ -2,6 +2,7 @@ package com.handwoong.rainbowletter.controller.member;
 
 import com.handwoong.rainbowletter.config.security.TokenResponse;
 import com.handwoong.rainbowletter.dto.member.ChangePasswordRequest;
+import com.handwoong.rainbowletter.dto.member.ChangePhoneNumberRequest;
 import com.handwoong.rainbowletter.dto.member.FindPasswordDto;
 import com.handwoong.rainbowletter.dto.member.MemberLoginRequest;
 import com.handwoong.rainbowletter.dto.member.MemberRegisterRequest;
@@ -53,6 +54,13 @@ public class MemberController {
     public ResponseEntity<Void> changePassword(@RequestBody @Valid final ChangePasswordRequest request) {
         final String email = SecurityUtils.getAuthenticationUsername();
         memberService.changePassword(email, request);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @PutMapping("/phoneNumber")
+    public ResponseEntity<Void> changePhoneNumber(@RequestBody @Valid final ChangePhoneNumberRequest request) {
+        final String email = SecurityUtils.getAuthenticationUsername();
+        memberService.changePhoneNumber(email, request);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/handwoong/rainbowletter/domain/member/Member.java
+++ b/src/main/java/com/handwoong/rainbowletter/domain/member/Member.java
@@ -3,9 +3,11 @@ package com.handwoong.rainbowletter.domain.member;
 import com.handwoong.rainbowletter.config.security.oauth.OAuthProvider;
 import com.handwoong.rainbowletter.domain.BaseEntity;
 import com.handwoong.rainbowletter.dto.member.ChangePasswordRequest;
+import com.handwoong.rainbowletter.dto.member.ChangePhoneNumberRequest;
 import com.handwoong.rainbowletter.dto.member.MemberRegisterRequest;
 import com.handwoong.rainbowletter.exception.ErrorCode;
 import com.handwoong.rainbowletter.exception.RainbowLetterException;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -34,6 +36,10 @@ public class Member extends BaseEntity {
 
     @NotNull
     private String password;
+
+    @Nullable
+    @Column(length = 20, unique = true)
+    private String phoneNumber;
 
     @NotNull
     @Enumerated(EnumType.STRING)
@@ -96,6 +102,10 @@ public class Member extends BaseEntity {
         if (!passwordEncoder.matches(password, this.password)) {
             throw new RainbowLetterException(ErrorCode.INVALID_PASSWORD);
         }
+    }
+
+    public void changePhoneNumber(final ChangePhoneNumberRequest request) {
+        this.phoneNumber = request.phoneNumber();
     }
 
     public void updateProvider(final OAuthProvider oAuthProvider, final String providerId) {

--- a/src/main/java/com/handwoong/rainbowletter/dto/ValidateMessage.java
+++ b/src/main/java/com/handwoong/rainbowletter/dto/ValidateMessage.java
@@ -8,6 +8,8 @@ public class ValidateMessage {
     public static final String EMPTY_MESSAGE = "항목을 입력해주세요.";
     public static final String EMAIL_MESSAGE = "유효하지 않은 이메일 형식입니다.";
     public static final String PASSWORD_MESSAGE = "비밀번호는 영문, 숫자를 조합하여 8자 이상으로 입력해주세요.";
+    public static final String PHONE_NUMBER_MESSAGE = "유효하지 않은 휴대폰 번호 형식입니다.";
 
     public static final String PASSWORD_FORMAT = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$";
+    public static final String PHONE_NUMBER_FORMAT = "^01[016789]\\d{7,8}$";
 }

--- a/src/main/java/com/handwoong/rainbowletter/dto/member/ChangePhoneNumberRequest.java
+++ b/src/main/java/com/handwoong/rainbowletter/dto/member/ChangePhoneNumberRequest.java
@@ -1,0 +1,15 @@
+package com.handwoong.rainbowletter.dto.member;
+
+import static com.handwoong.rainbowletter.dto.ValidateMessage.EMPTY_MESSAGE;
+import static com.handwoong.rainbowletter.dto.ValidateMessage.PHONE_NUMBER_FORMAT;
+import static com.handwoong.rainbowletter.dto.ValidateMessage.PHONE_NUMBER_MESSAGE;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record ChangePhoneNumberRequest(
+        @NotBlank(message = EMPTY_MESSAGE)
+        @Pattern(regexp = PHONE_NUMBER_FORMAT, message = PHONE_NUMBER_MESSAGE)
+        String phoneNumber
+) {
+}

--- a/src/main/java/com/handwoong/rainbowletter/service/member/MemberService.java
+++ b/src/main/java/com/handwoong/rainbowletter/service/member/MemberService.java
@@ -3,6 +3,7 @@ package com.handwoong.rainbowletter.service.member;
 import com.handwoong.rainbowletter.config.security.TokenResponse;
 import com.handwoong.rainbowletter.dto.mail.EmailDto;
 import com.handwoong.rainbowletter.dto.member.ChangePasswordRequest;
+import com.handwoong.rainbowletter.dto.member.ChangePhoneNumberRequest;
 import com.handwoong.rainbowletter.dto.member.FindPasswordDto;
 import com.handwoong.rainbowletter.dto.member.MemberLoginRequest;
 import com.handwoong.rainbowletter.dto.member.MemberRegisterRequest;
@@ -18,4 +19,6 @@ public interface MemberService {
     EmailDto findPassword(final FindPasswordDto request);
 
     void changePassword(final String email, final ChangePasswordRequest request);
+
+    void changePhoneNumber(final String email, final ChangePhoneNumberRequest request);
 }

--- a/src/main/java/com/handwoong/rainbowletter/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/handwoong/rainbowletter/service/member/MemberServiceImpl.java
@@ -7,6 +7,7 @@ import com.handwoong.rainbowletter.domain.member.Member;
 import com.handwoong.rainbowletter.domain.member.MemberStatus;
 import com.handwoong.rainbowletter.dto.mail.EmailDto;
 import com.handwoong.rainbowletter.dto.member.ChangePasswordRequest;
+import com.handwoong.rainbowletter.dto.member.ChangePhoneNumberRequest;
 import com.handwoong.rainbowletter.dto.member.FindPasswordDto;
 import com.handwoong.rainbowletter.dto.member.MemberLoginRequest;
 import com.handwoong.rainbowletter.dto.member.MemberRegisterRequest;
@@ -85,5 +86,13 @@ public class MemberServiceImpl implements MemberService {
         final Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new RainbowLetterException(ErrorCode.INVALID_EMAIL, email));
         member.changePassword(request, passwordEncoder);
+    }
+
+    @Override
+    @Transactional
+    public void changePhoneNumber(final String email, final ChangePhoneNumberRequest request) {
+        final Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new RainbowLetterException(ErrorCode.INVALID_EMAIL, email));
+        member.changePhoneNumber(request);
     }
 }

--- a/src/test/java/com/handwoong/rainbowletter/controller/member/MemberControllerTest.java
+++ b/src/test/java/com/handwoong/rainbowletter/controller/member/MemberControllerTest.java
@@ -15,6 +15,7 @@ import com.handwoong.rainbowletter.config.security.JwtTokenProvider;
 import com.handwoong.rainbowletter.config.security.TokenResponse;
 import com.handwoong.rainbowletter.controller.ControllerTestProvider;
 import com.handwoong.rainbowletter.dto.member.ChangePasswordRequest;
+import com.handwoong.rainbowletter.dto.member.ChangePhoneNumberRequest;
 import com.handwoong.rainbowletter.dto.member.FindPasswordDto;
 import com.handwoong.rainbowletter.dto.member.MemberLoginRequest;
 import com.handwoong.rainbowletter.dto.member.MemberRegisterRequest;
@@ -224,6 +225,32 @@ public class MemberControllerTest extends ControllerTestProvider {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 
+    @Test
+    @DisplayName("회원의 휴대폰 번호를 등록 또는 변경한다.")
+    void change_phone_number() {
+        // given
+        final ChangePhoneNumberRequest request = new ChangePhoneNumberRequest("01012345678");
+
+        // when
+        final ExtractableResponse<Response> response = changePhoneNumber(request, userAccessToken);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 휴대폰 번호 형식으로 휴대폰 번호를 변경한다.")
+    void invalid_phone_number() {
+        // given
+        final ChangePhoneNumberRequest request = new ChangePhoneNumberRequest("0101234");
+
+        // when
+        final ExtractableResponse<Response> response = changePhoneNumber(request, userAccessToken);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
     private ExtractableResponse<Response> register(final MemberRegisterRequest registerRequest, final String token) {
         return RestAssured
                 .given(getSpecification()).log().all()
@@ -268,6 +295,17 @@ public class MemberControllerTest extends ControllerTestProvider {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(request)
                 .when().put("/api/members/password")
+                .then().log().all().extract();
+    }
+
+    private ExtractableResponse<Response> changePhoneNumber(final ChangePhoneNumberRequest request,
+                                                            final String token) {
+        return RestAssured
+                .given(getSpecification()).log().all()
+                .header(AUTHORIZATION_HEADER_KEY, AUTHORIZATION_HEADER_TYPE + " " + token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when().put("/api/members/phoneNumber")
                 .then().log().all().extract();
     }
 }

--- a/src/test/java/com/handwoong/rainbowletter/domain/member/MemberTest.java
+++ b/src/test/java/com/handwoong/rainbowletter/domain/member/MemberTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.handwoong.rainbowletter.dto.member.ChangePasswordRequest;
+import com.handwoong.rainbowletter.dto.member.ChangePhoneNumberRequest;
 import com.handwoong.rainbowletter.dto.member.MemberRegisterRequest;
 import com.handwoong.rainbowletter.exception.ErrorCode;
 import com.handwoong.rainbowletter.exception.RainbowLetterException;
@@ -106,5 +107,20 @@ class MemberTest {
         assertThatThrownBy(() -> member.changePassword(changePasswordRequest, passwordEncoder))
                 .isInstanceOf(RainbowLetterException.class)
                 .hasMessage(ErrorCode.INVALID_PASSWORD.getMessage());
+    }
+
+    @Test
+    @DisplayName("회원의 휴대폰 번호를 변경한다.")
+    void changePhoneNumber() {
+        // given
+        final ChangePhoneNumberRequest request = new ChangePhoneNumberRequest("01012345678");
+        final MemberRegisterRequest registerRequest = new MemberRegisterRequest(NEW_EMAIL, NEW_PASSWORD);
+        final Member member = Member.create(registerRequest);
+
+        // when
+        member.changePhoneNumber(request);
+
+        // then
+        assertThat(member).extracting("phoneNumber").isEqualTo("01012345678");
     }
 }


### PR DESCRIPTION
## 설명

편지 작성 시 휴대폰 번호를 선택적으로 입력받는다.
다음번에 편지 작성 시 사용자가 재입력하지 않도록 회원 테이블에 휴대폰 번호를 저장한다.

## 구현

- [x] 휴대폰 번호 추가/수정

Close #53 